### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ Simple Social Sharing for Nuxt 3
 npx nuxi@latest module add nuxt-social-share
 ```
 
-2. Add `@stefanobartoletti/nuxt-social-share` to the `modules` section of `nuxt.config.ts`
+2. Nuxi should have already added `@stefanobartoletti/nuxt-social-share` to the `modules` section of `nuxt.config.ts`, if not add it manually:
 
 ```js
 export default defineNuxtConfig({
+  // module added by Nuxi
   modules: [
     '@stefanobartoletti/nuxt-social-share'
   ],
-  // optional configuration
+  // optional configuration, should be added manually
   socialShare: {
     // module options
   }

--- a/README.md
+++ b/README.md
@@ -30,12 +30,7 @@ Simple Social Sharing for Nuxt 3
 1. Add `@stefanobartoletti/nuxt-social-share` dependency to your project
 
 ```bash
-# pnpm
-pnpm add -D @stefanobartoletti/nuxt-social-share
-# yarn
-yarn add --dev @stefanobartoletti/nuxt-social-share
-# npm
-npm install --save-dev @stefanobartoletti/nuxt-social-share
+npx nuxi@latest module add nuxt-social-share
 ```
 
 2. Add `@stefanobartoletti/nuxt-social-share` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your PR in detail. If it resolves an open issue, please link to the issue here. For example "Resolves: #17" -->

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
