### PR TITLE
fix(props): reactive

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -5,8 +5,22 @@
         <h1 class="font-bold text-xl">Nuxt Social Share</h1>
       </div>
       <div class="flex-none">
-        <a class="btn btn-square btn-ghost" href="https://github.com/stefanobartoletti/nuxt-social-share" target="_blank">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33c.85 0 1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2Z" /></svg>
+        <a
+          class="btn btn-square btn-ghost"
+          href="https://github.com/stefanobartoletti/nuxt-social-share"
+          target="_blank"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill="currentColor"
+              d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33c.85 0 1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2Z"
+            />
+          </svg>
         </a>
       </div>
     </div>
@@ -15,15 +29,24 @@
   <main class="container py-16">
     <div class="join join-vertical">
       <!-- Instances -->
-      <div v-for="(instance, index) in instances" :key="index" class="collapse collapse-arrow join-item border border-base-300">
+      <div
+        v-for="(instance, index) in instances"
+        :key="index"
+        class="collapse collapse-arrow join-item border border-base-300"
+      >
         <input type="radio" name="accordion" />
-        <div class="collapse-title text-xl font-medium bg-base-200 rounded-none">
+        <div
+          class="collapse-title text-xl font-medium bg-base-200 rounded-none"
+        >
           <h2>{{ instance.title }}</h2>
         </div>
 
         <div class="collapse-content">
           <div class="flex flex-col lg:flex-row lg:p-8 lg:pt-12 gap-8">
-            <div class="buttons-container flex flex-wrap gap-2 p-8 justify-center content-center w-auto lg:w-1/2" :class="instance.class">
+            <div
+              class="buttons-container flex flex-wrap gap-2 p-8 justify-center content-center w-auto lg:w-1/2"
+              :class="instance.class"
+            >
               <SocialShare
                 v-for="network in testNetworks"
                 :key="network"
@@ -36,9 +59,23 @@
               <h3 class="text-lg font-medium">By using props:</h3>
               <pre>{{ `<SocialShare\n\t:styled="${instance.styled}"\n\t:label="${instance.label}"\n/>` }}</pre>
               <h3 class="text-lg font-medium">By using options:</h3>
-              <pre>{{ `export default defineNuxtConfig({\n\tsocialShare: {\n\t\tstyled: ${instance.styled},\n\t\tlabel: ${instance.label},\n\t}\n})` }}</pre>
+              <pre>{{
+                `export default defineNuxtConfig({\n\tsocialShare: {\n\t\tstyled: ${instance.styled},\n\t\tlabel: ${instance.label},\n\t}\n})`
+              }}</pre>
               <div v-if="instance.note" role="alert" class="alert">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-info shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  class="stroke-info shrink-0 w-6 h-6"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
                 <span>{{ instance.note }}</span>
               </div>
             </div>
@@ -49,18 +86,20 @@
       <!-- Composable -->
       <div class="collapse collapse-arrow join-item border border-base-300">
         <input type="radio" name="accordion" />
-        <div class="collapse-title text-xl font-medium bg-base-200 rounded-none">
+        <div
+          class="collapse-title text-xl font-medium bg-base-200 rounded-none"
+        >
           <h2>Composable</h2>
         </div>
 
         <div class="collapse-content">
           <div class="flex flex-col lg:p-8 lg:pt-12">
-            <div class="p-4 w-auto  flex flex-col gap-4">
+            <div class="p-4 w-auto flex flex-col gap-4">
               <h3 class="text-lg font-medium">Usage example:</h3>
               <pre>{{ `<script setup>\nconst getFacebook = useSocialShare({ network: 'facebook' })\n</script>` }}</pre>
             </div>
 
-            <div class="p-4 w-auto  flex flex-col gap-4">
+            <div class="p-4 w-auto flex flex-col gap-4">
               <h3 class="text-lg font-medium">Returned object:</h3>
               <pre>{{ getFacebook }}</pre>
             </div>
@@ -70,16 +109,81 @@
       <!-- Using all props -->
       <div class="collapse collapse-arrow join-item border border-base-300">
         <input type="radio" name="accordion" />
-        <div class="collapse-title text-xl font-medium bg-base-200 rounded-none">
+        <div
+          class="collapse-title text-xl font-medium bg-base-200 rounded-none"
+        >
           <h2>Complete share URLs when using all Props</h2>
         </div>
 
         <div class="collapse-content">
-          <div class="flex flex-col  lg:p-8 lg:pt-12">
+          <div class="flex flex-col lg:p-8 lg:pt-12">
             <div class="p-4 w-auto flex flex-col gap-8">
-              <div v-for="item in getAllNetworks()" :key="item" class="" :url="item">
+              <div
+                v-for="item in getAllNetworks()"
+                :key="item"
+                class=""
+                :url="item"
+              >
                 <p>{{ item.value.name }}</p>
                 <pre>{{ item.value.shareUrl }}</pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Reactive -->
+      <div class="collapse collapse-arrow join-item border border-base-300">
+        <input type="radio" name="accordion" />
+        <div
+          class="collapse-title text-xl font-medium bg-base-200 rounded-none"
+        >
+          <h2>{{ urlInstance.title }}</h2>
+        </div>
+
+        <div class="collapse-content">
+          <div class="flex flex-col lg:p-8 lg:pt-12">
+            <div class="p-4 w-auto flex flex-col gap-4">
+              <SocialShare
+                network="telegram"
+                :styled="urlInstance.styled"
+                :label="urlInstance.label"
+                :url="urlInstance.url"
+                :class="urlInstance.class"
+              />
+              <p>
+                Current url is: {{ urlInstance.url }} (click the social button
+                or mouse over on it to see the change)
+              </p>
+              <button
+                class="border w-min p-4 text-white self-center text-nowrap rounded"
+                @click="changeUrl"
+              >
+                Change url
+              </button>
+              <h3 class="text-lg font-medium">Usage example (component):</h3>
+              <pre>{{ `<script setup>
+const url = ref<string | undefined>(undefined)
+url.value = "https://www.example.com"
+</script>\n<template>\n<SocialShare :url="url" />\n</template>` }}</pre>
+              <h3 class="text-lg font-medium">Usage example (composable):</h3>
+              <pre>{{ `<script setup>\nconst getNetwork = useSocialShare({ url: undefined })
+getNetwork.value.shareUrl = getNetwork.value.updateUrl("new url")\n</script>` }}</pre>
+
+              <div v-if="urlInstance.note" role="alert" class="alert">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  class="stroke-info shrink-0 w-6 h-6"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span>{{ urlInstance.note }}</span>
               </div>
             </div>
           </div>
@@ -91,6 +195,7 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { networksIndex } from '../src/runtime/networksIndex'
 import { useSocialShare } from '#imports'
 
@@ -129,18 +234,36 @@ const instances = [
   },
 ]
 
+const urlInstance = {
+  title: 'Reactive url option',
+  styled: true,
+  label: true,
+  class: 'text-white self-center',
+  note: `'url' is 'undefined' by default, and can be omitted here to change it.`,
+  url: ref('/index'),
+}
+
+const isIndexPage = ref(true)
+
+const changeUrl = () => {
+  isIndexPage.value = !isIndexPage.value
+  urlInstance.url.value = isIndexPage.value ? '/index' : '/about'
+}
+
 const getAllNetworks = () => {
   const allNetworks = []
 
   testNetworks.forEach((el) => {
-    allNetworks.push(useSocialShare({
-      network: el,
-      url: 'https://www.example.com/',
-      title: 'Test Title',
-      user: 'test_user',
-      hashtags: 'test,hashtags',
-      image: 'https://www.example.com/image.jpg',
-    }))
+    allNetworks.push(
+      useSocialShare({
+        network: el,
+        url: 'https://www.example.com/',
+        title: 'Test Title',
+        user: 'test_user',
+        hashtags: 'test,hashtags',
+        image: 'https://www.example.com/image.jpg',
+      }),
+    )
   })
 
   return allNetworks

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -161,13 +161,13 @@
                 Change url
               </button>
               <h3 class="text-lg font-medium">Usage example (component):</h3>
-              <pre>{{ `<script setup>
+              <pre>{{ `<script setup lang="ts">
 const url = ref<string | undefined>(undefined)
 url.value = "https://www.example.com"
 </script>\n<template>\n<SocialShare :url="url" />\n</template>` }}</pre>
               <h3 class="text-lg font-medium">Usage example (composable):</h3>
               <pre>{{ `<script setup>\nconst getNetwork = useSocialShare({ url: undefined })
-getNetwork.value.shareUrl = getNetwork.value.updateUrl("new url")\n</script>` }}</pre>
+getNetwork.value.updateUrl("new url")\n</script>` }}</pre>
 
               <div v-if="urlInstance.note" role="alert" class="alert">
                 <svg

--- a/src/runtime/SocialShare.vue
+++ b/src/runtime/SocialShare.vue
@@ -1,24 +1,32 @@
 <template>
   <a
     class="social-share-button"
-    :class="[`social-share-button--${network}`, { 'social-share-button--styled': isStyled }]"
-    :href="selectedNework.shareUrl"
+    :class="[
+      `social-share-button--${network}`,
+      { 'social-share-button--styled': isStyled },
+    ]"
+    :href="fullUrl"
     :style="`--color-brand:${selectedNework.color}`"
     :aria-label="`Share with ${capitalizedNetwork}`"
     target="_blank"
   >
-    <svg class="social-share-button__icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img" width="1em" height="1em" :viewBox="`${selectedNework.icon.viewBox}`">
+    <svg
+      class="social-share-button__icon"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      role="img"
+      width="1em"
+      height="1em"
+      :viewBox="`${selectedNework.icon.viewBox}`"
+    >
       <path fill="currentColor" :d="`${selectedNework.icon.path}`" />
     </svg>
-    <span
-      v-if="isLabeled"
-      class="social-share-button__label"
-    >Share</span>
+    <span v-if="isLabeled" class="social-share-button__label">Share</span>
   </a>
 </template>
 
 <script setup>
-import { computed } from "vue"
+import { computed, toRefs } from 'vue'
 import { useSocialShare } from './useSocialShare'
 import { useRuntimeConfig } from '#imports'
 
@@ -33,21 +41,28 @@ const props = defineProps({
   image: { type: String, default: undefined },
 })
 
+const { url } = toRefs(props)
+
 const options = useRuntimeConfig().public.socialShare
 
 const isStyled = props.styled !== undefined ? props.styled : options.styled
-const isLabeled = computed(() => props.label !== undefined ? props.label : options.label)
+const isLabeled = computed(() =>
+  props.label !== undefined ? props.label : options.label,
+)
 
 const selectedNework = useSocialShare({
   network: props.network,
-  url: props.url,
+  url: url.value,
   title: props.title,
   user: props.user,
   hashtags: props.hashtags,
   image: props.image,
 })
 
-const capitalizedNetwork = props.network.charAt(0).toUpperCase() + props.network.slice(1)
+const fullUrl = computed(() => selectedNework.value.updateUrl(url.value))
+
+const capitalizedNetwork
+  = props.network.charAt(0).toUpperCase() + props.network.slice(1)
 </script>
 
 <style lang="scss">

--- a/src/runtime/SocialShare.vue
+++ b/src/runtime/SocialShare.vue
@@ -5,7 +5,7 @@
       `social-share-button--${network}`,
       { 'social-share-button--styled': isStyled },
     ]"
-    :href="fullUrl"
+    :href="selectedNework.shareUrl"
     :style="`--color-brand:${selectedNework.color}`"
     :aria-label="`Share with ${capitalizedNetwork}`"
     target="_blank"
@@ -26,7 +26,7 @@
 </template>
 
 <script setup>
-import { computed, toRefs } from 'vue'
+import { computed, toRefs, watch } from 'vue'
 import { useSocialShare } from './useSocialShare'
 import { useRuntimeConfig } from '#imports'
 
@@ -59,10 +59,12 @@ const selectedNework = useSocialShare({
   image: props.image,
 })
 
-const fullUrl = computed(() => selectedNework.value.updateUrl(url.value))
-
 const capitalizedNetwork
   = props.network.charAt(0).toUpperCase() + props.network.slice(1)
+
+watch(url, (newValue) => {
+  selectedNework.value.updateUrl(newValue)
+})
 </script>
 
 <style lang="scss">

--- a/src/runtime/SocialShare.vue
+++ b/src/runtime/SocialShare.vue
@@ -18,6 +18,7 @@
 </template>
 
 <script setup>
+import { computed } from "vue"
 import { useSocialShare } from './useSocialShare'
 import { useRuntimeConfig } from '#imports'
 
@@ -35,7 +36,7 @@ const props = defineProps({
 const options = useRuntimeConfig().public.socialShare
 
 const isStyled = props.styled !== undefined ? props.styled : options.styled
-const isLabeled = props.label !== undefined ? props.label : options.label
+const isLabeled = computed(() => props.label !== undefined ? props.label : options.label)
 
 const selectedNework = useSocialShare({
   network: props.network,

--- a/src/runtime/useSocialShare.ts
+++ b/src/runtime/useSocialShare.ts
@@ -28,7 +28,7 @@ export function useSocialShare(options: Options = defaultOptions) {
   const argHashtags = (selectedNework.value.args?.hashtags && hashtags) ? selectedNework.value.args?.hashtags : ''
   const argImage = (selectedNework.value.args?.image && image) ? selectedNework.value.args?.image : ''
 
-  let fullUrl = `${shareUrl}${argTitle}${argUser}${argHashtags}${argImage}`
+  let fullUrl = shareUrl + argTitle + argUser + argHashtags + argImage
   // Replace placeholders with actual values
   fullUrl = fullUrl
     .replace(/\[u\]/i, pageUrl)

--- a/src/runtime/useSocialShare.ts
+++ b/src/runtime/useSocialShare.ts
@@ -18,27 +18,32 @@ export function useSocialShare(options: Options = defaultOptions) {
   // Get network. Using a shallow copy to avoid mutating the original object
   const selectedNework = ref({ ...networksIndex[network] })
 
-  // Set default value for url if not provided from options
-  const pageUrl = url !== undefined ? url : useRequestURL().href
+  const updateUrl = (_url: string): string => {
+    // Set default value for url if not provided from options
+    const pageUrl = _url !== undefined ? _url : useRequestURL().href
 
-  // Build full share raw url
-  const shareUrl = selectedNework.value.shareUrl
-  const argTitle = (selectedNework.value.args?.title && title) ? selectedNework.value.args?.title : ''
-  const argUser = (selectedNework.value.args?.user && user) ? selectedNework.value.args?.user : ''
-  const argHashtags = (selectedNework.value.args?.hashtags && hashtags) ? selectedNework.value.args?.hashtags : ''
-  const argImage = (selectedNework.value.args?.image && image) ? selectedNework.value.args?.image : ''
+    // Build full share raw url
+    const shareUrl = networksIndex[network].shareUrl
+    const argTitle = (networksIndex[network].args?.title && title) ? networksIndex[network].args?.title : ''
+    const argUser = (networksIndex[network].args?.user && user) ? networksIndex[network].args?.user : ''
+    const argHashtags = (networksIndex[network].args?.hashtags && hashtags) ? networksIndex[network].args?.hashtags : ''
+    const argImage = (networksIndex[network].args?.image && image) ? networksIndex[network].args?.image : ''
 
-  let fullUrl = shareUrl + argTitle + argUser + argHashtags + argImage
-  // Replace placeholders with actual values
-  fullUrl = fullUrl
-    .replace(/\[u\]/i, pageUrl)
-    .replace(/\[t\]/i, title || '')
-    .replace(/\[uid\]/i, user || '')
-    .replace(/\[h\]/i, hashtags || '')
-    .replace(/\[i\]/i, image || '')
+    let fullUrl = shareUrl + argTitle + argUser + argHashtags + argImage
+
+    // Replace placeholders with actual values
+    fullUrl = fullUrl
+      .replace(/\[u\]/i, pageUrl)
+      .replace(/\[t\]/i, title || '')
+      .replace(/\[uid\]/i, user || '')
+      .replace(/\[h\]/i, hashtags || '')
+      .replace(/\[i\]/i, image || '')
+    return fullUrl
+  }
 
   // Rebuild selectedNework object
-  selectedNework.value.shareUrl = fullUrl
+  selectedNework.value.shareUrl = updateUrl(url)
+  selectedNework.value.updateUrl = updateUrl
   delete selectedNework.value.args
 
   return selectedNework

--- a/src/runtime/useSocialShare.ts
+++ b/src/runtime/useSocialShare.ts
@@ -28,8 +28,7 @@ export function useSocialShare(options: Options = defaultOptions) {
   const argHashtags = (selectedNework.value.args?.hashtags && hashtags) ? selectedNework.value.args?.hashtags : ''
   const argImage = (selectedNework.value.args?.image && image) ? selectedNework.value.args?.image : ''
 
-  let fullUrl = shareUrl + argTitle + argUser + argHashtags + argImage
-
+  let fullUrl = `${shareUrl}${argTitle}${argUser}${argHashtags}${argImage}`
   // Replace placeholders with actual values
   fullUrl = fullUrl
     .replace(/\[u\]/i, pageUrl)

--- a/src/runtime/useSocialShare.ts
+++ b/src/runtime/useSocialShare.ts
@@ -18,7 +18,7 @@ export function useSocialShare(options: Options = defaultOptions) {
   // Get network. Using a shallow copy to avoid mutating the original object
   const selectedNework = ref({ ...networksIndex[network] })
 
-  const updateUrl = (_url: string): string => {
+  const updateUrl = (_url: string): void => {
     // Set default value for url if not provided from options
     const pageUrl = _url !== undefined ? _url : useRequestURL().href
 
@@ -29,20 +29,19 @@ export function useSocialShare(options: Options = defaultOptions) {
     const argHashtags = (networksIndex[network].args?.hashtags && hashtags) ? networksIndex[network].args?.hashtags : ''
     const argImage = (networksIndex[network].args?.image && image) ? networksIndex[network].args?.image : ''
 
-    let fullUrl = shareUrl + argTitle + argUser + argHashtags + argImage
+    const fullUrl = shareUrl + argTitle + argUser + argHashtags + argImage
 
     // Replace placeholders with actual values
-    fullUrl = fullUrl
+    selectedNework.value.shareUrl = fullUrl
       .replace(/\[u\]/i, pageUrl)
       .replace(/\[t\]/i, title || '')
       .replace(/\[uid\]/i, user || '')
       .replace(/\[h\]/i, hashtags || '')
       .replace(/\[i\]/i, image || '')
-    return fullUrl
   }
 
   // Rebuild selectedNework object
-  selectedNework.value.shareUrl = updateUrl(url)
+  updateUrl(url)
   selectedNework.value.updateUrl = updateUrl
   delete selectedNework.value.args
 


### PR DESCRIPTION
### Type of change
*  Breaking change (fix or feature that would cause existing functionality to change)

### Description
I noticed that some prop values (eg. label, url etc.) are immutable, once set, which is frustrating. In some cases, I need to change those settings dynamically, especially when I globally share the component in my app. But any method I tried to update the needed props was pointless, as long as the component prevents this, and I see no reason why.

For example, the `url` prop, when `undefined`, it gets the URL from the browser and keeps that value until an app reload, which is not good.

Let's suppose I have the component inside `app.vue`
```
<template>
  <SocialShare
    network="facebook"
    styled="true"
    label="false"
    :url="currentUrl"
   />
</template>

<script setup lang="ts">
const currentUrl = ref<string | undefined>(undefined)
</script>
```

where `url` gets the app link with current path (so initializing it with `undefined` is fine), and I expect it to update its value whenever and wherever I need, like on page change event, from `/index` to `/about`.

If I try to change it manually
`currentUrl.value = "whatever url string I have in mind"`
or while watching the `useRoute` composable, the component gets unaffected.

Same for `label` (I fixed it first because it was easier), when I wanted it dynamically based on screen mode, like showing it on desktop and hiding it on mobile.




### 📝 Checklist
* [x]  Make `label` reactive
* [x]  Make `url` reactive
