### PR TITLE
Update useSocialShare.ts

### DIFF
--- a/src/runtime/useSocialShare.ts
+++ b/src/runtime/useSocialShare.ts
@@ -46,7 +46,7 @@ export function useSocialShare(options: Options = defaultOptions) {
 
     // Replace placeholders with actual values
     fullUrl = fullUrl
-      .replace(/\[u\]/i, pageUrl.value)
+      .replace(/\[u\]/i, encodeURIComponent(pageUrl.value))
       .replace(/\[t\]/i, title || '')
       .replace(/\[uid\]/i, user || '')
       .replace(/\[h\]/i, hashtags || '')


### PR DESCRIPTION
Make sure pageUrls with multiple params can be open  Example: https://domain.tld/path/?a=123&b=test
without encoding the pageUrl params get cut off when open the share link

<!--- Provide a general summary of your changes in the title above -->

<!--
IMPORTANT!
Before submitting a PR, make sure to read the Contributing Guidelines here https://github.com/stefanobartoletti/nuxt-social-share/blob/main/.github/CONTRIBUTING.md
Some especially important points:
- open an issue to discuss your proposed bugfix or new feature, before even starting to work on the actual code. This is required to make sure that your effort will be put into good use by receiving a preliminary feedback and indications about how to work on it, and in case of new features, if they are in scope for the project and actually needed.
- provide concise but informative and understandable description about your contributions.
- make sure to use the provided ESLint configuration to lint your code and adhere to the current coding standards.
-->

## Description
<!--- Describe your PR in detail. If it resolves an open issue, please link to the issue here. For example "Resolves: #17" -->
