### PR TITLE
Implement lazy loading of networks

### DIFF
--- a/docs/content/2.usage/2.composable.md
+++ b/docs/content/2.usage/2.composable.md
@@ -14,14 +14,14 @@ Like the component, one instance of `useSocialShare` should be used for every ne
 ```vue
 <script setup>
 // Basic minimal use, network property is required
-const shareFacebook = useSocialShare({ network: 'facebook' })
+const shareFacebook = await useSocialShare({ network: 'facebook' })
 </script>
 ```
 
 ```vue
 <script setup>
 // All possible options
-const shareFacebook = useSocialShare({
+const shareFacebook = await useSocialShare({
   network: 'facebook', // Required!
   url: 'https://www.example.com', // Optional, defaults to current page URL if not provided
   title: 'My Custom Title', // Optional, available on networks supporting it

--- a/playground/pages/composable.vue
+++ b/playground/pages/composable.vue
@@ -28,7 +28,7 @@
 <script setup>
 import { useSocialShare } from '#imports'
 
-const getFacebook = useSocialShare({ network: 'facebook' })
+const getFacebook = await useSocialShare({ network: 'facebook' })
 </script>
 
 <style>

--- a/playground/pages/urls.vue
+++ b/playground/pages/urls.vue
@@ -25,14 +25,14 @@
 
 <script setup>
 import { useSocialShare } from '#imports'
-import { networksIndex } from '../../src/runtime/networksIndex'
+import { networksBase } from '../../src/runtime/networksIndex'
 
-const testNetworks = Object.keys(networksIndex)
+const testNetworks = Object.keys(networksBase)
 
 const allNetworks = []
 
-testNetworks.forEach((el) => {
-  allNetworks.push(useSocialShare({
+for (const el of testNetworks) {
+  allNetworks.push(await useSocialShare({
     network: el,
     url: 'https://www.example.com/',
     title: 'Test Title',
@@ -40,7 +40,7 @@ testNetworks.forEach((el) => {
     hashtags: 'test,hashtags',
     image: 'https://www.example.com/image.jpg',
   }))
-})
+}
 </script>
 
 <style>

--- a/src/runtime/SocialShare.vue
+++ b/src/runtime/SocialShare.vue
@@ -44,7 +44,7 @@ const isStyled = props.styled !== undefined ? props.styled : moduleOptions.style
 const isLabeled = props.label !== undefined ? props.label : moduleOptions.label
 const hasIcon = props.icon !== undefined ? props.icon : moduleOptions.icon
 
-const selectedNetwork = useSocialShare({
+const selectedNetwork = await useSocialShare({
   network: props.network,
   url: props.url,
   title: props.title,

--- a/src/runtime/networksIndex.ts
+++ b/src/runtime/networksIndex.ts
@@ -1,46 +1,24 @@
-import type { NetworksIndex } from './types'
+import type { Network } from './types'
 
-import { bluesky } from './networks/bluesky'
-import { email } from './networks/email'
-import { facebook } from './networks/facebook'
-import { line } from './networks/line'
-import { linkedin } from './networks/linkedin'
-import { pinterest } from './networks/pinterest'
-import { pocket } from './networks/pocket'
-import { reddit } from './networks/reddit'
-import { skype } from './networks/skype'
-import { telegram } from './networks/telegram'
-import { threads } from './networks/threads'
-import { viber } from './networks/viber'
-import { whatsapp } from './networks/whatsapp'
-import { x } from './networks/x'
+const networkImporters = import.meta.glob('./networks/*.ts')
 
-export const networksBase: NetworksIndex = {
-  // Social Networks
-  facebook,
-  x,
-  linkedin,
-  pinterest,
-  reddit,
-  bluesky,
-  threads,
-  // Read it later
-  pocket,
-  // Instant Messaging
-  whatsapp,
-  telegram,
-  skype,
-  line,
-  viber,
-  // Other
-  email,
+export const networksBase = Object.fromEntries(
+  Object.keys(networkImporters).map((path) => {
+    const name = path.split('/').pop()?.replace('.ts', '') as string
+    return [name, name]
+  }),
+) as Record<string, string>
+
+export const networksAlias: Record<string, string> = {
+  twitter: 'x',
 }
 
-export const networksAlias: NetworksIndex = {
-  twitter: x,
-}
+export async function getNetwork(name: string): Promise<Network> {
+  const target = networksAlias[name] || name
+  const importer = networkImporters[`./networks/${target}.ts`]
+  if (!importer)
+    throw new Error(`Unsupported network: '${name}'`)
 
-export const networksIndex: NetworksIndex = {
-  ...networksBase,
-  ...networksAlias,
+  const mod: any = await importer()
+  return mod[target] as Network
 }

--- a/src/runtime/useSocialShare.ts
+++ b/src/runtime/useSocialShare.ts
@@ -1,7 +1,7 @@
 import type { Options } from './types/'
 
 import { computed, ref, useRoute, useRuntimeConfig } from '#imports'
-import { networksIndex } from './networksIndex'
+import { getNetwork } from './networksIndex'
 
 const defaultOptions = {
   network: '',
@@ -12,12 +12,12 @@ const defaultOptions = {
   image: undefined,
 }
 
-export function useSocialShare(options: Options = defaultOptions) {
+export async function useSocialShare(options: Options = defaultOptions) {
   const { network, url, title, user, hashtags, image } = options
   const moduleOptions = useRuntimeConfig().public.socialShare
 
   // Get network. Using a shallow copy to avoid mutating the original object
-  const selectedNetwork = ref({ ...networksIndex[network] })
+  const selectedNetwork = ref(await getNetwork(network))
   const route = useRoute()
 
   // Set default value for url if not provided from options


### PR DESCRIPTION
## Summary
- implement dynamic import of networks and expose helper
- update composable to load networks lazily
- adapt SocialShare component and playground code
- document async composable usage

## Testing
- `npx eslint . --fix` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684fc83e26f8832d8d9723c2ac6028a5